### PR TITLE
Allow byte compilation of all Elisp files

### DIFF
--- a/el/common-plw.el
+++ b/el/common-plw.el
@@ -68,7 +68,8 @@
     (setq *js-vars-to-reset* (make-hash-table :test 'eq)))
   `(progn
      (dolist (w (if (consp ,when) ,when (list ,when)))
-       (pushnew ',varname (gethash w *js-vars-to-reset*)))
+       (when (and w *js-vars-to-reset*)
+	 (pushnew ',varname (gethash w *js-vars-to-reset*))))
      ,(if local
 	  `(defvar-local ,varname ,def)
 	`(defvar ,varname ,def))))

--- a/el/opx2-js-cache.el
+++ b/el/opx2-js-cache.el
@@ -222,8 +222,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun js-reset-vars (type)
-  (dolist (item (gethash type *js-vars-to-reset*))
-    (setf (symbol-value item) nil)))
+  (when (and type *js-vars-to-reset*)
+    (dolist (item (gethash type *js-vars-to-reset*))
+      (setf (symbol-value item) nil))))
 
 
 (defun ojs-reset-cache-on-save ()

--- a/el/pjs-mode-syntax.el
+++ b/el/pjs-mode-syntax.el
@@ -833,7 +833,7 @@
   (set (make-local-variable 'comment-end) "")
 
   (when *pjs-font-lock-debug*
-    (load (format "%s/devenv/el/pjs-mode-debug.el" *opx2-network-folder-work-path*)))
+    (load (format "%s/devenv/el/pjs-mode-debug" *opx2-network-folder-work-path*)))
 
   (if *pjs-font-lock-debug*      
       (set (make-local-variable 'font-lock-defaults)

--- a/el/pjs-mode.el
+++ b/el/pjs-mode.el
@@ -105,7 +105,7 @@
 		    (format "method.%s.%s" word
 			    (if (or (string= (car type) "plc")
 				    (string= (car type) "plw"))
-				(or (and (list-pjs-plc-types-to-kernel)
+				(or (and (cdr type) (list-pjs-plc-types-to-kernel)
 					 (gethash (cdr type) (list-pjs-plc-types-to-kernel)))
 				    (cdr type))
 			      (format "%s.%s" (car type) (cdr type)))))
@@ -121,7 +121,7 @@
 			    (match-string-no-properties 1)
 			    (if (or (string= (car type) "plc")
 				    (string= (car type) "plw"))
-				(or (and (list-pjs-plc-types-to-kernel)
+				(or (and (cdr type) (list-pjs-plc-types-to-kernel)
 					 (gethash (cdr type) (list-pjs-plc-types-to-kernel)))
 				    (cdr type))
 			      (format "%s.%s" (car type) (cdr type)))))

--- a/emacs-plw-ext.el
+++ b/emacs-plw-ext.el
@@ -13,32 +13,32 @@
 ;; use opx2-js-mode
 (defvar *use-opx2-js-mode* t)
 
-(load (fullpath-relative-to-current-file "el/packages.el"))
-(load (fullpath-relative-to-current-file "el/common-plw.el"))
-(load (fullpath-relative-to-current-file "el/connect-is.el"))
-(load (fullpath-relative-to-current-file "el/source-code-plw.el"))
-(load (fullpath-relative-to-current-file "el/source-colorization.el"))
-(load (fullpath-relative-to-current-file "el/eli-plw.el"))
+(load (fullpath-relative-to-current-file "el/packages"))
+(load (fullpath-relative-to-current-file "el/common-plw"))
+(load (fullpath-relative-to-current-file "el/connect-is"))
+(load (fullpath-relative-to-current-file "el/source-code-plw"))
+(load (fullpath-relative-to-current-file "el/source-colorization"))
+(load (fullpath-relative-to-current-file "el/eli-plw"))
 
 
 (when *use-opx2-js-mode*
-  (load (fullpath-relative-to-current-file "el/opx2-js-cache.el"))
-  (load (fullpath-relative-to-current-file "el/opx2-js-mode-syntax.el"))
-  (load (fullpath-relative-to-current-file "el/opx2-js-mode.el"))
-  (load (fullpath-relative-to-current-file "el/ac-opx2js.el"))
+  (load (fullpath-relative-to-current-file "el/opx2-js-cache"))
+  (load (fullpath-relative-to-current-file "el/opx2-js-mode-syntax"))
+  (load (fullpath-relative-to-current-file "el/opx2-js-mode"))
+  (load (fullpath-relative-to-current-file "el/ac-opx2js"))
 
-;;  (load (fullpath-relative-to-current-file "el/pjs-semantic.el"))
-  (load (fullpath-relative-to-current-file "el/pjs-mode-syntax.el"))
-  (load (fullpath-relative-to-current-file "el/pjs-semantic.el"))
-  (load (fullpath-relative-to-current-file "el/ac-pjs.el"))
-  (load (fullpath-relative-to-current-file "el/pjs-mode.el"))
-  ;;  (load (fullpath-relative-to-current-file "el/yasnippet.el"))
+;;  (load (fullpath-relative-to-current-file "el/pjs-semantic"))
+  (load (fullpath-relative-to-current-file "el/pjs-mode-syntax"))
+  (load (fullpath-relative-to-current-file "el/pjs-semantic"))
+  (load (fullpath-relative-to-current-file "el/ac-pjs"))
+  (load (fullpath-relative-to-current-file "el/pjs-mode"))
+  ;;  (load (fullpath-relative-to-current-file "el/yasnippet"))
   )
 
-(load (fullpath-relative-to-current-file "el/ac-config.el"))
+(load (fullpath-relative-to-current-file "el/ac-config"))
 
 (when (eq *javascript-evaluator-mode* :repl)
-  (load (fullpath-relative-to-current-file "el/javascript-evaluator.el")))
+  (load (fullpath-relative-to-current-file "el/javascript-evaluator")))
 
 (defvar *custom-theme* 'tangotango)
 

--- a/runtime/src/emacs.el
+++ b/runtime/src/emacs.el
@@ -3,6 +3,6 @@
 ;; Distributed under the MIT License
 ;; See accompanying file LICENSE file or copy at http://opensource.org/licenses/MIT
 
-(load (format "%seli/fi-site-init.el" *opx2-network-folder-work-path*))
-(load (format "%sdevenv/emacs-plw-ext.el" *opx2-network-folder-work-path*))
-(load (format "%sopx2-runtime.el" *opx2-network-folder-work-path*))
+(load (format "%seli/fi-site-init" *opx2-network-folder-work-path*))
+(load (format "%sdevenv/emacs-plw-ext" *opx2-network-folder-work-path*))
+(load (format "%sopx2-runtime" *opx2-network-folder-work-path*))


### PR DESCRIPTION
Hi, as mentioned in a previous email: This PR allows byte compilation for all Elisp files.

7bbaa68 The gethash function sometimes fails for byte compiled files, so we need to make sure that the hashtable and key are not nil before we use them. 

fcd5f58 The load function does not need to be called with an extension. See here:
https://www.emacswiki.org/emacs/LoadingLispFiles
> This will load the CompiledFile (having the “.elc” extension) if it exists, otherwise the source file (with “.el” extension).

Everything should work as before, even if you decide to not compile your files.